### PR TITLE
Add JSON:API Hypermedia as a dependency

### DIFF
--- a/fluid_comment.info.yml
+++ b/fluid_comment.info.yml
@@ -4,5 +4,6 @@ description: Enhances the user experience of your site's comment system.
 package: Core
 core: 8.x
 dependencies:
-  - drupal:jsonapi
   - drupal:comment
+  - drupal:jsonapi
+  - drupal:jsonapi_hypermedia


### PR DESCRIPTION
In order to know whether a comment is editable or deletable by the current user, we need to know if that operation is permitted on a resource object's `self` link.

The JSON:API Hypermedia module adds this information by adding addition link relations based on account access.