### PR TITLE
Approve / Unpublish / Delete

### DIFF
--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -44,7 +44,7 @@ function processLinks(links) {
     const { href } = link;
 
     if (key === 'self') {
-      const rel = getDeepProp(link, 'meta.linkRel');
+      const rel = getDeepProp(link, 'meta.linkParams');
       const methods = getMethodsFromRel(rel);
 
       methods.forEach(method => {
@@ -127,7 +127,7 @@ class FluidComment extends React.Component {
             </div>
             {links && <ul className="links inline">
               {links.map(link => (
-                <li className={link.className}>
+                <li key={`${comment.id}-${link.className}`} className={link.className}>
                   <FluidCommentLink link={link} handleClick={(e) => this.commentAction(e, link)} />
                 </li>
               ))}

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -26,7 +26,7 @@ class FluidComment extends React.Component {
       article: [
         'comment',
         'js-comment',
-        `comment--${published}`,
+        !published && `comment--unpublished`,
         // 'by-anonymous'
         // 'by-' ~ commented_entity.getEntityTypeId() ~ '-author'
         'clearfix'

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -41,30 +41,20 @@ function processLinks(links) {
   Object.keys(links).forEach(key => {
 
     const link = links[key];
+    const params = getDeepProp(link, 'meta.linkParams');
     const { href } = link;
+    const { rel } = params;
+    const data = params.data ? params.data : {};
 
-    if (key === 'self') {
-      const rel = getDeepProp(link, 'meta.linkParams');
-      const methods = getMethodsFromRel(rel);
+    const methods = getMethodsFromRel(rel);
 
-      methods.forEach(method => {
-        const title = getSelfTitle(method);
-        processed.push(processLink({ title, href, method }));
-      })
-    }
-    else {
-      const params = getDeepProp(link, 'meta.linkParams');
+    methods.forEach(method => {
+      const title = key === 'self'
+        ? getSelfTitle(method)
+        : getLinkTitles(key);
 
-      if (params) {
-        const { rel, data } = params;
-        const title = getLinkTitles(key);
-        const methods = getMethodsFromRel(rel);
-
-        methods.forEach(method => {
-          processed.push(processLink({ title, href, method, data }));
-        });
-      }
-    }
+      processed.push(processLink({ title, href, method, data }));
+    });
   });
 
   return processed;
@@ -147,7 +137,7 @@ class FluidComment extends React.Component {
     }
 
     getResponseDocument(href, options).then(() => {
-      console.log(`Called ${link.title} with ${options.method} for ${href}`);
+      // console.log(`Called ${link.title} with ${options.method} for ${href}`);
       this.props.refresh();
     });
   }

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -54,7 +54,12 @@ function processLinks(links) {
         title = key;
       }
 
-      if (rel.find(value => value.match(new RegExp(`${method}$`)))) {
+      const pattern = new RegExp(`${method}$`);
+      const match = Array.isArray(rel)
+        ? rel.find(value => value.match(pattern))
+        : rel.match(pattern);
+
+      if (match) {
         processed.push(processLink({ title, href, method, data }));
       }
     });

--- a/js/src/FluidCommentLink.js
+++ b/js/src/FluidCommentLink.js
@@ -1,0 +1,9 @@
+'use strict';
+
+import React from 'react';
+
+const FluidCommentLink = ({ link, handleClick }) => (
+  <a href="#" onClick={handleClick}>{ link.title }</a>
+);
+
+export default FluidCommentLink;

--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -33,7 +33,7 @@ class FluidCommentWrapper extends React.Component {
           key={comment.id}
           index={index}
           comment={comment}
-          onDelete={() => this.refreshComments()}
+          refresh={() => this.refreshComments()}
         />
       )));
     }

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -45,7 +45,6 @@ export function getResponseDocument(url, options = {}) {
     return fetch(url, options).then(response => {
       return response.status !== 204 ? response.json() : null;
     }).then(doc => {
-      console.log(url, doc);
       return doc;
     }).catch(console.log);
   });

--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -1,0 +1,11 @@
+
+export function getMethodsFromRel(rel) {
+  const methods = {
+    'https://jsonapi.org/profiles/drupal/hypermedia/#update': 'PATCH',
+    'https://jsonapi.org/profiles/drupal/hypermedia/#delete': 'DELETE'
+  };
+
+  return Array.isArray(rel)
+    ? rel.map(route => methods[route]).filter(route => route !== undefined)
+    : methods[rel] ? [methods[rel]] : [];
+}


### PR DESCRIPTION
With jsonapi_hypermedia, `publish` and `unpublish` links are now available. It also seemed to change the `self` links for update and delete.

This creates links for each comment depending on permissions.

Clicking Approve / Unpublish or Delete will send a request then refresh the comments list.

Edit does not work yet, that will be revisited with https://github.com/gabesullice/fluid_comment/issues/5

