### PR TITLE
Handle users without pictures

### DIFF
--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -72,9 +72,9 @@ class FluidCommentWrapper extends React.Component {
 
       if (users.length > 0) {
         let user = users[0];
-        const pic = getDeepProp(user, 'relationships.user_picture');
+        const pic = getDeepProp(user, 'relationships.user_picture.data');
         if (pic) {
-          const pictures = included.filter(item => item.id === pic.data.id);
+          const pictures = included.filter(item => item.id === pic.id);
           if (pictures.length > 0) {
             user = Object.assign(user, { picture: pictures[0] });
           }


### PR DESCRIPTION
Simple fix. If a user doesn't have a picture, `relationships.user_data.data` will be `null`.