### PR TITLE
Hide comments and/or comment form depending on hypermedia controls

### DIFF
--- a/fluid_comment.module
+++ b/fluid_comment.module
@@ -11,7 +11,6 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\user\EntityOwnerInterface;
 
@@ -42,13 +41,4 @@ function fluid_comment_comment_access(EntityInterface $entity, $operation, Accou
     default:
       return AccessResult::neutral();
   }
-}
-
-/**
- * Implements hook_jsonapi_ENTITY_TYPE_filter_access() for 'comment'.
- */
-function fluid_comment_jsonapi_comment_filter_access(EntityTypeInterface $entity_type, AccountInterface $account) {
-  return ([
-    JSONAPI_FILTER_AMONG_OWN => AccessResult::allowedIfHasPermission($account, 'access comments')->andIf(AccessResult::allowedIf(!$account->isAnonymous())->addCacheContexts(['user.roles:anonymous'])),
-  ]);
 }

--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -27,7 +27,7 @@ class FluidCommentWrapper extends React.Component {
   };
 
   render() {
-    const { commentsUrl, currentNode, loginUrl, commentType } = this.props;
+    const { currentNode, loginUrl, commentType } = this.props;
     const { comments, loggedIn, isRefreshing } = this.state;
 
     return (

--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -1,6 +1,7 @@
 'use strict';
 import React from 'react';
 import { getDeepProp, getResponseDocument } from './functions';
+import { getRelUri, objectHasLinkWithRel } from './routes';
 import FluidComment from './FluidComment';
 import FluidCommentForm from './FluidCommentForm';
 import InlineLoginForm from "./InlineLoginForm";
@@ -18,14 +19,6 @@ class FluidCommentWrapper extends React.Component {
 
   componentDidMount() {
     this.refreshComments();
-  }
-
-  filteredCommentsUrl() {
-    const { hostId, commentsUrl } = this.props;
-    const id = 'entity_id.id';
-    const include = 'uid.user_picture';
-
-    return `${commentsUrl}/?filter[${id}]=${hostId}&include=${include}`;
   }
 
   onLogin = (success) => {
@@ -58,7 +51,7 @@ class FluidCommentWrapper extends React.Component {
               onLogin={this.onLogin}
             />
           </div>
-        : <div>
+        : objectHasLinkWithRel(currentNode, 'comments', getRelUri('add')) && <div>
             <h2 className="title comment-form__title">Add new comment</h2>
             <FluidCommentForm
               key="commentForm"
@@ -75,7 +68,9 @@ class FluidCommentWrapper extends React.Component {
   }
 
   refreshComments() {
-    this.getAndAddComments(this.filteredCommentsUrl());
+    if (objectHasLinkWithRel(this.props.currentNode, 'comments', getRelUri('collection'))) {
+      this.getAndAddComments(`${this.props.currentNode.links.comments.href}/?include=uid.user_picture`);
+    }
   }
 
   /**
@@ -105,7 +100,6 @@ class FluidCommentWrapper extends React.Component {
   }
 
   getAndAddComments(commentsUrl, previous = []) {
-
     this.setState({ isRefreshing: true });
 
     getResponseDocument(commentsUrl).then(doc => {

--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -1,11 +1,26 @@
+import { getDeepProp } from './functions';
+
+export function getRelUri(alias) {
+  const rels = {
+    'add': 'https://jsonapi.org/profiles/drupal/hypermedia/#add',
+    'update': 'https://jsonapi.org/profiles/drupal/hypermedia/#update',
+    'delete': 'https://jsonapi.org/profiles/drupal/hypermedia/#delete',
+    'collection': 'collection',
+  };
+  return rels[alias];
+}
 
 export function getMethodsFromRel(rel) {
-  const methods = {
-    'https://jsonapi.org/profiles/drupal/hypermedia/#update': 'PATCH',
-    'https://jsonapi.org/profiles/drupal/hypermedia/#delete': 'DELETE'
-  };
+  const methods = {};
+  methods[getRelUri('update')] = 'PATCH',
+  methods[getRelUri('delete')] = 'DELETE'
 
   return Array.isArray(rel)
     ? rel.map(route => methods[route]).filter(route => route !== undefined)
     : methods[rel] ? [methods[rel]] : [];
+}
+
+export function objectHasLinkWithRel(obj, key, rel) {
+  const rels = getDeepProp(obj, `links.${key}.meta.linkParams.rel`);
+  return Array.isArray(rels) && rels.includes(rel);
 }


### PR DESCRIPTION
This conditionally hide comments based on the presence and rels of the `comments` link on the node entity.

Also, since we have this new `comments` route, we don't need to filter comments. Which means JSON:API's filter access control does not apply, which means there is no problem with depth limits (!)