### PR TITLE
Add/omit comment links based on user permissions

### DIFF
--- a/modules/jsonapi_comment/jsonapi_comment.services.yml
+++ b/modules/jsonapi_comment/jsonapi_comment.services.yml
@@ -5,7 +5,9 @@ services:
 
   jsonapi_comment.jsonapi_hypermedia_provider:
     class: Drupal\jsonapi_comment\HypermediaProvider\DefaultProvider
-    arguments: ['@jsonapi.resource_type.repository']
+    arguments:
+      - '@jsonapi.resource_type.repository'
+      - '@current_user'
     tags:
       - { name: jsonapi_hypermedia_provider, priority: 0 }
 

--- a/modules/jsonapi_comment/src/HypermediaProvider/DefaultProvider.php
+++ b/modules/jsonapi_comment/src/HypermediaProvider/DefaultProvider.php
@@ -137,7 +137,7 @@ class DefaultProvider implements HypermediaProviderInterface {
     $link_relations = [];
     $view_access = AccessResult::allowedIfHasPermission($this->currentUser, 'access comments');
     $link_collection = $this->withLinkCollectionCacheability($link_collection, $view_access);
-    if ($field->status != CommentItemInterface::HIDDEN || !$view_access->isAllowed()) {
+    if ($field->status != CommentItemInterface::HIDDEN && $view_access->isAllowed()) {
       $link_relations[] = 'collection';
     }
     $post_access = AccessResult::allowedIfHasPermission($this->currentUser, 'post comments');

--- a/modules/jsonapi_comment/src/HypermediaProvider/DefaultProvider.php
+++ b/modules/jsonapi_comment/src/HypermediaProvider/DefaultProvider.php
@@ -4,8 +4,11 @@ namespace Drupal\jsonapi_comment\HypermediaProvider;
 
 use Drupal\comment\CommentFieldItemList;
 use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\jsonapi\JsonApiResource\Link;
 use Drupal\jsonapi\JsonApiResource\LinkCollection;
@@ -29,13 +32,23 @@ class DefaultProvider implements HypermediaProviderInterface {
   protected $resourceTypeRepository;
 
   /**
+   * The current user account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
    * DefaultProvider constructor.
    *
    * @param \Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface $resource_type_repository
    *   The JSON:API resource type repository.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user account.
    */
-  public function __construct(ResourceTypeRepositoryInterface $resource_type_repository) {
+  public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $current_user) {
     $this->resourceTypeRepository = $resource_type_repository;
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -78,6 +91,11 @@ class DefaultProvider implements HypermediaProviderInterface {
     if (!$host_entity->hasField($field_name) || $host_entity->{$field_name}->status != CommentItemInterface::OPEN) {
       return $link_collection;
     }
+    $post_access = AccessResult::allowedIfHasPermission($this->currentUser, 'post comments');
+    $link_collection = $this->withLinkCollectionCacheability($link_collection, $post_access);
+    if (!$post_access->isAllowed()) {
+      return $link_collection;
+    }
     $public_field_name = $comment_object->getResourceType()->getPublicName($field_name);
     $host_resource_type = $this->resourceTypeRepository->get($host_entity->getEntityTypeId(), $host_entity->bundle());
     $reply_route_name = "jsonapi.{$host_resource_type->getTypeName()}.jsonapi_comment.{$public_field_name}.child_reply";
@@ -117,11 +135,18 @@ class DefaultProvider implements HypermediaProviderInterface {
       return $link_collection;
     }
     $link_relations = [];
-    if ($field->status != CommentItemInterface::HIDDEN) {
+    $view_access = AccessResult::allowedIfHasPermission($this->currentUser, 'access comments');
+    $link_collection = $this->withLinkCollectionCacheability($link_collection, $view_access);
+    if ($field->status != CommentItemInterface::HIDDEN || !$view_access->isAllowed()) {
       $link_relations[] = 'collection';
     }
-    if ($field->status == CommentItemInterface::OPEN) {
+    $post_access = AccessResult::allowedIfHasPermission($this->currentUser, 'post comments');
+    $link_collection = $this->withLinkCollectionCacheability($link_collection, $post_access);
+    if ($field->status == CommentItemInterface::OPEN && $post_access->isAllowed()) {
       $link_relations[] = 'https://jsonapi.org/profiles/drupal/hypermedia/#add';
+    }
+    if (!$view_access->orIf($post_access)->isAllowed()) {
+      return $link_collection;
     }
     $link_attributes = [
       'linkParams' => ['rel' => $link_relations],
@@ -129,10 +154,40 @@ class DefaultProvider implements HypermediaProviderInterface {
     ];
     if (!empty($link_relations)) {
       $cacheability = CacheableMetadata::createFromObject($commented_resource_object);
+      $cacheability->addCacheContexts(['user.permissions']);
       $link = new Link($cacheability, $comments_url, $link_relations, $link_attributes);
       return $link_collection->withLink('comments', $link);
     }
     return $link_collection;
+  }
+
+  /**
+   * Adds cacheability to a link collection without adding a new link.
+   *
+   * This is necessary when the *absence* of a link needs to be varied by some
+   * cacheable metadata, such as when a user does not have permission to follow
+   * a link.
+   *
+   * @param \Drupal\jsonapi\JsonApiResource\LinkCollection $link_collection
+   *   The link collection that needs the additional cacheability metadata. The
+   *   collection must not be empty.
+   * @param \Drupal\Core\Cache\CacheableDependencyInterface $cacheability
+   *   The extra cacheability metadata.
+   *
+   * @return \Drupal\jsonapi\JsonApiResource\LinkCollection
+   *   The modified link collection.
+   */
+  protected function withLinkCollectionCacheability(LinkCollection $link_collection, CacheableDependencyInterface $cacheability) {
+    foreach ($link_collection as $key => $links) {
+      foreach  ($links as $link) {
+        assert($link instanceof Link);
+        $cacheability = CacheableMetadata::createFromObject($link)->addCacheableDependency($cacheability);
+        $replace = new Link($cacheability, $link->getUri(), $link->getLinkRelationTypes(), $link->getTargetAttributes());
+        break 2;
+      }
+    }
+    assert(isset($key) && isset($replace), 'This method must be passed a non-empty link collection.');
+    return $link_collection->withLink($key, $replace);
   }
 
 }


### PR DESCRIPTION
This adds or omits links and link relations based on access and applies the correct cacheability metadata to the response for them.

This behavior will
- hide the `comments` link for users without the `access comments` permission.
- omit the `.../#add` link relation from the `comments` link for users who have `access comments` but _not_ the `post comments` permission.
- omit the `reply` link for users who do not have the `post comments` permission.
