### PR TITLE
Remove the host type and host ID data attributes.

### DIFF
--- a/fluid_comment.module
+++ b/fluid_comment.module
@@ -21,8 +21,7 @@ function fluid_comment_theme($existing, $type, $theme, $path) {
   return [
     'fluid_comment_formatter' => [
       'variables' => [
-        'comment_target_type' => NULL,
-        'comment_target_id' => NULL,
+        'commented_resource_url' => NULL,
         'comment_type' => NULL,
         'comment_display_mode' => NULL,
       ],

--- a/js/src/FluidCommentWidget.js
+++ b/js/src/FluidCommentWidget.js
@@ -16,28 +16,25 @@ class FluidCommentWidget extends React.Component {
     }
 
     componentDidMount() {
+        const { commentedResourceUrl } = this.props;
         getResponseDocument(entryPointUrl).then(responseDoc => {
-            const nodeUrl = getDeepProp(responseDoc, `links.${this.props.hostType}.href`) + `/${this.props.hostId}`;
-            const userId = getDeepProp(responseDoc, 'meta.links.me.meta.id');
-            const loggedIn = userId !== false;
-            this.setState({ loggedIn, userId });
-            getResponseDocument(nodeUrl).then(currentNode => {
+            const loggedIn = getDeepProp(responseDoc, 'meta.links.me.href') !== false;
+            this.setState({loggedIn});
+            getResponseDocument(commentedResourceUrl).then(currentNode => {
                 this.setState({currentNode: getDeepProp(currentNode, 'data')});
             });
         });
     }
 
     render() {
-        const { currentNode, loggedIn, userId } = this.state;
-        const { hostId, commentType } = this.props;
-
-        return (currentNode &&
+        const { currentNode, loggedIn } = this.state;
+        const { commentType } = this.props;
+        const show = currentNode && objectHasLinkWithRel(currentNode, 'comments', getRelUri('collection'));
+        return (show &&
           <FluidCommentWrapper
             loginUrl={loggedIn === false ? loginUrl : null}
-            currentUserId={userId}
             commentType={commentType}
             currentNode={currentNode}
-            hostId={hostId}
           />
         );
     }

--- a/js/src/FluidCommentWidget.js
+++ b/js/src/FluidCommentWidget.js
@@ -30,6 +30,7 @@ class FluidCommentWidget extends React.Component {
         const { currentNode, loggedIn } = this.state;
         const { commentType } = this.props;
         const show = currentNode && objectHasLinkWithRel(currentNode, 'comments', getRelUri('collection'));
+
         return (show &&
           <FluidCommentWrapper
             loginUrl={loggedIn === false ? loginUrl : null}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -12,9 +12,8 @@ export { getResponseDocument, getDeepProp, getUrl } from './functions';
 document.addEventListener("DOMContentLoaded", function() {
   const domContainer = document.querySelector('#fluid-comment-root');
   if (domContainer) {
-    const hostType = domContainer.getAttribute('data-jsonapi-comment-target-type');
-    const hostId = domContainer.getAttribute('data-jsonapi-comment-target-id');
+    const commentedResourceUrl = domContainer.getAttribute('data-fluid-comment-commented-resource-url');
     const commentType = domContainer.getAttribute('data-jsonapi-comment-type');
-    render(<FluidCommentWidget commentType={commentType} hostType={hostType} hostId={hostId} />, domContainer);
+    render(<FluidCommentWidget commentType={commentType} commentedResourceUrl={commentedResourceUrl} />, domContainer);
   }
 });

--- a/templates/fluid-comment-formatter.html.twig
+++ b/templates/fluid-comment-formatter.html.twig
@@ -27,5 +27,5 @@
  */
 #}
 <section{{ attributes }}>
-  <div id="fluid-comment-root" data-jsonapi-comment-target-type="{{ comment_target_type }}" data-jsonapi-comment-target-id="{{ comment_target_id }}" data-jsonapi-comment-type="{{ comment_type }}" ></div>
+  <div id="fluid-comment-root" data-fluid-comment-commented-resource-url="{{ commented_resource_url }}" data-jsonapi-comment-type="{{ comment_type }}" ></div>
 </section>


### PR DESCRIPTION
This gets rid of the `data-jsonapi-comment-target-type` and `data-jsonapi-comment-target-id` data attributes that are used to bootstrap the commenting component in favor of a JSON:API URL for the entity being commented upon. This will be more effective in fully-decoupled scenarios and once the login form is take out, we'll likely be able to remove the `FluidCommentWidget` component because it will have become unnecessary.

This is still in a draft because I would like to also remove the `data-jsonapi-comment-type` attribute as well, but I think that that will likely have large conflicts with #20.

Side note: This also reverts the addition of the ckeditor libraries. It seemed like too small of a change to make in a separate PR that would conflict with this one.