### PR TITLE
Fix format of PATCH payload for comment update

### DIFF
--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -1,6 +1,6 @@
 'use strict';
 import React from 'react';
-import { getDeepProp, getResponseDocument, formatRequest, getFormKey } from './functions';
+import { getDeepProp, getResponseDocument, formatBodyAdd, getFormKey } from './functions';
 import { getRelUri, objectHasLinkWithRel } from './routes';
 
 import FluidCommentList from './FluidCommentList';
@@ -76,10 +76,11 @@ class FluidCommentWrapper extends React.Component {
     const { currentNode: node, commentType: type } = this.props;
     const commentsUrl = getDeepProp(node, 'links.comments.href');
     const field = getDeepProp(node, 'links.comments.meta.commentFieldName');
-    const request = formatRequest(values, 'POST', node, type, field);
+    const body = formatBodyAdd(values, node, field, type);
+    const method = 'POST';
 
     if (objectHasLinkWithRel(node, 'comments', getRelUri('add'))) {
-      getResponseDocument(commentsUrl, request).then(doc => {
+      getResponseDocument(commentsUrl, { method, body }).then(doc => {
         if (!doc.errors) {
           this.refreshComments();
           this.resetForm();

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -69,8 +69,7 @@ export function getResponseDocument(url, options = {}) {
   });
 }
 
-export function formatRequest(values, method, node, field, type) {
-
+export function formatBodyAdd(values, node, field, type) {
   const { subjectField, bodyField } = values;
 
   const attributes = {
@@ -92,10 +91,19 @@ export function formatRequest(values, method, node, field, type) {
     }
   };
 
-  const requestDocument = { data: { attributes, relationships, type } };
+  return JSON.stringify({ data: { attributes, relationships, type } });
+}
 
-  return {
-    method,
-    body: JSON.stringify(requestDocument)
+export function formatBodyUpdate(values, id, type) {
+  const { subjectField, bodyField } = values;
+
+  const attributes = {
+    subject: subjectField,
+    comment_body: {
+      value: bodyField,
+      format: 'restricted_html',
+    },
   };
+
+  return JSON.stringify({ data: { id, attributes, type } });
 }


### PR DESCRIPTION
The format of the `body` is different for a PATCH than a POST, mainly that the `id` is required.

This change uses separate methods for formatting the body of a comment.
The "Edit" link should now work correctly and not return a `400`.