### PR TITLE
Comment meta

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2100,6 +2100,11 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -3640,8 +3640,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -3654,6 +3653,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "jump.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jump.js/-/jump.js-1.0.1.tgz",
+      "integrity": "sha1-DeKxYxupocLGuFcq0nfYd+hQNgA="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -3702,7 +3706,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -3983,8 +3986,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4222,7 +4224,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4336,8 +4337,16 @@
     "react-is": {
       "version": "16.8.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
-      "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
-      "dev": true
+      "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ=="
+    },
+    "react-scrollable-anchor": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/react-scrollable-anchor/-/react-scrollable-anchor-0.6.1.tgz",
+      "integrity": "sha1-/W54Amx0T3ZBQFPQaQO4KtzLVNk=",
+      "requires": {
+        "jump.js": "1.0.1",
+        "prop-types": "^15.5.10"
+      }
     },
     "readable-stream": {
       "version": "2.3.6",

--- a/js/package.json
+++ b/js/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "webpack --mode production"
   },
-  "dependencies": {},
+  "dependencies": {
+    "date-fns": "^1.30.1"
+  },
   "peerDependencies": {
     "react": "16.x"
   },

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,8 @@
     "build": "webpack --mode production"
   },
   "dependencies": {
-    "date-fns": "^1.30.1"
+    "date-fns": "^1.30.1",
+    "react-scrollable-anchor": "^0.6.1"
   },
   "peerDependencies": {
     "react": "16.x"

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -4,6 +4,8 @@ import React from 'react';
 import FluidCommentContent from './FluidCommentContent';
 import FluidCommentForm from './FluidCommentForm';
 import FluidCommentAction from './FluidCommentAction';
+import FluidCommentAuthor from './FluidCommentAuthor';
+
 import { getDeepProp, getResponseDocument, getFormKey, formatBodyAdd, formatBodyUpdate } from './functions.js';
 import { getMetaFromRel } from './routes.js';
 
@@ -92,7 +94,8 @@ class FluidComment extends React.Component {
 
     const author = {
       name: getDeepProp(comment, 'user.attributes.name'),
-      image: getDeepProp(comment, 'user.picture.attributes.uri.url')
+      image: getDeepProp(comment, 'user.picture.attributes.uri.url'),
+      url: getDeepProp(comment, 'user.url')
     };
 
     const classes = {
@@ -120,8 +123,7 @@ class FluidComment extends React.Component {
         <article role="article" className={classes.article.join(' ')}>
           <span className="hidden" data-comment-timestamp="{{ new_indicator_timestamp }}"></span>
           <footer className="comment__meta">
-            {author.image && <img src={author.image} alt={author.name} />}
-            <p className="comment__author">{author.name}</p>
+            <FluidCommentAuthor author={author} />
             <p className="comment__time">created</p>
             <p className="comment__permalink">permalink</p>
             <p className="visually-hidden">parent</p>

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { format } from 'date-fns';
+import ScrollableAnchor from 'react-scrollable-anchor';
 
 import FluidCommentContent from './FluidCommentContent';
 import FluidCommentForm from './FluidCommentForm';
@@ -127,37 +128,39 @@ class FluidComment extends React.Component {
     const permaLink = `comment-${cid}`;
 
     return (
-      <React.Fragment>
-        <article role="article" className={classes.article.join(' ')} id={permaLink}>
-          <span className="hidden" data-comment-timestamp={format(new Date(changed), 'X')}></span>
-          <footer className="comment__meta">
-            <FluidCommentAuthor author={author} />
-            <p className="comment__time">{format(new Date(created), dateFormat)}</p>
-            <p className="comment__permalink"><a href={`#${permaLink}`}>Permalink</a></p>
-            <p className="visually-hidden">parent</p>
-          </footer>
-          {action !== null && action.name !== 'reply'
-            ? <FluidCommentAction
-                name={action.name}
-                title={action.title}
-                subject={subject}
-                body={body}
-                handleEdit={this.saveComment}
-                handleConfirm={this.commentConfirm}
-                handleCancel={this.commentCancel}
-                formKey={`${formKey}-edit`}
-                isRefreshing={isRefreshing}
-              />
-            : <FluidCommentContent
-                id={comment.id}
-                subject={subject}
-                body={body}
-                classes={classes}
-                links={links}
-                permaLink={permaLink}
-                action={this.commentAction}
-              />}
-        </article>
+      <>
+        <ScrollableAnchor id={permaLink}>
+          <article role="article" className={classes.article.join(' ')}>
+            <span className="hidden" data-comment-timestamp={format(new Date(changed), 'X')}></span>
+            <footer className="comment__meta">
+              <FluidCommentAuthor author={author} />
+              <p className="comment__time">{format(new Date(created), dateFormat)}</p>
+              <p className="comment__permalink"><a href={`#${permaLink}`}>Permalink</a></p>
+              <p className="visually-hidden">parent</p>
+            </footer>
+            {action !== null && action.name !== 'reply'
+              ? <FluidCommentAction
+                  name={action.name}
+                  title={action.title}
+                  subject={subject}
+                  body={body}
+                  handleEdit={this.saveComment}
+                  handleConfirm={this.commentConfirm}
+                  handleCancel={this.commentCancel}
+                  formKey={`${formKey}-edit`}
+                  isRefreshing={isRefreshing}
+                />
+              : <FluidCommentContent
+                  id={comment.id}
+                  subject={subject}
+                  body={body}
+                  classes={classes}
+                  links={links}
+                  permaLink={permaLink}
+                  action={this.commentAction}
+                />}
+          </article>
+        </ScrollableAnchor>
         {(action !== null && action.name === 'reply') &&
           <FluidCommentForm
             key={formKey}
@@ -167,7 +170,7 @@ class FluidComment extends React.Component {
           />
         }
         {children && children.length ? <div className="indented">{children}</div> : null}
-      </React.Fragment>
+      </>
     );
   }
 

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import React from 'react';
+import { format } from 'date-fns';
+
 import FluidCommentContent from './FluidCommentContent';
 import FluidCommentForm from './FluidCommentForm';
 import FluidCommentAction from './FluidCommentAction';
@@ -90,6 +92,8 @@ class FluidComment extends React.Component {
     const subject = getDeepProp(comment, 'attributes.subject');
     const body = getDeepProp(comment, 'attributes.comment_body.processed');
     const published = getDeepProp(comment, 'attributes.status');
+    const created = getDeepProp(comment, 'attributes.created');
+    const changed = getDeepProp(comment, 'attributes.changed');
     const links = processLinks(comment.links);
 
     const author = {
@@ -118,13 +122,15 @@ class FluidComment extends React.Component {
       ]
     };
 
+    const dateFormat = 'ddd, MM/DD/YYYY';
+
     return (
       <React.Fragment>
         <article role="article" className={classes.article.join(' ')}>
-          <span className="hidden" data-comment-timestamp="{{ new_indicator_timestamp }}"></span>
+          <span className="hidden" data-comment-timestamp={format(new Date(changed), 'X')}></span>
           <footer className="comment__meta">
             <FluidCommentAuthor author={author} />
-            <p className="comment__time">created</p>
+            <p className="comment__time">{format(new Date(created), dateFormat)}</p>
             <p className="comment__permalink">permalink</p>
             <p className="visually-hidden">parent</p>
           </footer>

--- a/js/src/FluidComment.js
+++ b/js/src/FluidComment.js
@@ -89,6 +89,7 @@ class FluidComment extends React.Component {
     const { comment, isRefreshing, children } = this.props;
     const { action, formKey } = this.state;
 
+    const cid = getDeepProp(comment, 'attributes.drupal_internal__cid');
     const subject = getDeepProp(comment, 'attributes.subject');
     const body = getDeepProp(comment, 'attributes.comment_body.processed');
     const published = getDeepProp(comment, 'attributes.status');
@@ -123,15 +124,16 @@ class FluidComment extends React.Component {
     };
 
     const dateFormat = 'ddd, MM/DD/YYYY';
+    const permaLink = `comment-${cid}`;
 
     return (
       <React.Fragment>
-        <article role="article" className={classes.article.join(' ')}>
+        <article role="article" className={classes.article.join(' ')} id={permaLink}>
           <span className="hidden" data-comment-timestamp={format(new Date(changed), 'X')}></span>
           <footer className="comment__meta">
             <FluidCommentAuthor author={author} />
             <p className="comment__time">{format(new Date(created), dateFormat)}</p>
-            <p className="comment__permalink">permalink</p>
+            <p className="comment__permalink"><a href={`#${permaLink}`}>Permalink</a></p>
             <p className="visually-hidden">parent</p>
           </footer>
           {action !== null && action.name !== 'reply'
@@ -152,6 +154,7 @@ class FluidComment extends React.Component {
                 body={body}
                 classes={classes}
                 links={links}
+                permaLink={permaLink}
                 action={this.commentAction}
               />}
         </article>

--- a/js/src/FluidCommentAuthor.js
+++ b/js/src/FluidCommentAuthor.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const FluidCommentAuthor = ({ author }) => (
+  <>
+    {(author.image && author.url) &&
+      <article
+        className="contextual-region profile"
+        typeof="schema:Person"
+        about={author.url}
+      >
+        <div className="field field--type-image">
+          <a href={author.url}>
+            <img
+              src={author.image}
+              width="100"
+              height="100"
+              alt={`Profile picture for user ${author.name}`}
+              typeof="foaf:Image"
+              className="image-style-thumbnail"
+            />
+          </a>
+        </div>
+      </article>
+    }
+    <p className="comment__author">
+      {author.url
+        ? <a
+            title="View user profile."
+            href={author.url}
+            about={author.url}
+            typeof="schema:Person"
+            property="schema:name"
+            className="username"
+          >
+            {author.name}
+          </a>
+        : author.name
+      }
+    </p>
+  </>
+);
+
+export default FluidCommentAuthor;

--- a/js/src/FluidCommentContent.js
+++ b/js/src/FluidCommentContent.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import FluidCommentLink from './FluidCommentLink';
 
-const FluidCommentContent = ({ id, subject, body, classes, links, action }) => (
+const FluidCommentContent = ({ id, subject, body, classes, links, permaLink, action }) => (
   <div className="comment__content">
-    <h3>{ subject }</h3>
+    <h3><a href={`#${permaLink}`}>{subject}</a></h3>
     <div
       className={classes.content.join(' ')}
       dangerouslySetInnerHTML={{__html: body}}>

--- a/js/src/FluidCommentForm.js
+++ b/js/src/FluidCommentForm.js
@@ -22,7 +22,7 @@ class FluidCommentForm extends React.Component {
       <div>
         <form className="comment-comment-form comment-form" onSubmit={this.handleSubmit}>
           <div className="form-item">
-            <label for="subjectField">Subject</label>
+            <label htmlFor="subjectField">Subject</label>
             <input
               type="text"
               name="subjectField"
@@ -34,7 +34,7 @@ class FluidCommentForm extends React.Component {
           </div>
           <div className="text-format-wrapper form-item">
             <div className="form-type-textarea form-item">
-              <label for="bodyField" className="form-required">Body</label>
+              <label htmlFor="bodyField" className="form-required">Body</label>
               <div className="form-textarea-wrapper">
                 <textarea
                   type="text"

--- a/js/src/FluidCommentWrapper.js
+++ b/js/src/FluidCommentWrapper.js
@@ -31,7 +31,7 @@ class FluidCommentWrapper extends React.Component {
     const show = currentNode && objectHasLinkWithRel(currentNode, 'comments', getRelUri('collection'));
 
     return (
-      <div>
+      <>
       {show &&
         <FluidCommentList
           threaded={threaded}
@@ -52,7 +52,7 @@ class FluidCommentWrapper extends React.Component {
           />
         </div>
       }
-      </div>
+      </>
     );
   }
 
@@ -98,11 +98,17 @@ class FluidCommentWrapper extends React.Component {
       if (users.length > 0) {
         let user = users[0];
         const pic = getDeepProp(user, 'relationships.user_picture.data');
+        const uid = getDeepProp(user, 'attributes.drupal_internal__uid');
+
         if (pic) {
           const pictures = included.filter(item => item.id === pic.id);
           if (pictures.length > 0) {
             user = Object.assign(user, { picture: pictures[0] });
           }
+        }
+
+        if (uid) {
+          user = Object.assign(user, { url: `/user/${uid}`});
         }
 
         return Object.assign(comment, { user });


### PR DESCRIPTION
Added a package for formatting dates, and another for handling the permalink scrolling.

This update moves author info into its own component for easier formatting, and passes the user id in to print a link to that user page. This only applies to users that have the permission to view the user account (and picture). #39 

The timestamp for "changed" is now in the span in case we revisit #7 
And the date is formatted as the default "long" style.

The comment cid is used for a "permalink" #25 
Now clicking a permlink or subject will scroll to that comment, opening a page with an anchor in the url will scroll to the comment.

There is also a small fix to change `for=` to `htmlFor=` in form labels.